### PR TITLE
new tuple constructors

### DIFF
--- a/src/tuple17.lib/tuple17/Tuple.h
+++ b/src/tuple17.lib/tuple17/Tuple.h
@@ -263,10 +263,6 @@ private:
     }
 };
 
-// Deduction guide to allow easy in-place construction
-// template<class... Ts>
-// Tuple(Ts&&...)->Tuple<std::remove_cv_t<std::remove_reference_t<Ts>>...>;
-
 template<size_t I, class... Ts>
 auto constexpr get(Tuple<Ts...>& tuple) -> decltype(auto) {
     return tuple.at(_const<I>);

--- a/src/tuple17.lib/tuple17/Tuple.h
+++ b/src/tuple17.lib/tuple17/Tuple.h
@@ -147,7 +147,9 @@ public:
         return res;
     }
 
-    template<class = std::enable_if_t<sizeof...(Ts) != 0>>
+    template<
+        bool workaround_to_enable_sfinae = sizeof...(Ts) >= 1,
+        class = typename std::enable_if<workaround_to_enable_sfinae>>
     constexpr Tuple(const Ts&... ts) {
         ((new (this->ptrOf<Ts>()) Ts(ts)), ...);
     }

--- a/src/tuple17.lib/tuple17/Tuple.test.cpp
+++ b/src/tuple17.lib/tuple17/Tuple.test.cpp
@@ -175,35 +175,16 @@ TEST(Tuple, construction) {
     // auto a3 = Ambiguous{'c', 23, 32};
 }
 
-TEST(Tuple, broaden) {
+TEST(Tuple, fromTuple) {
     using Small = Tuple<char, int, double>;
     using Large = Tuple<int, double, char, float>;
     auto s = Small{'c', 23, 4.2};
-    auto l = Large(s);
+    auto l = Large::fromTuple(s);
 
     EXPECT_EQ((l.of<char>()), 'c');
     EXPECT_EQ((l.of<double>()), 4.2);
     EXPECT_EQ((l.of<int>()), 23);
     EXPECT_EQ((l.of<float>()), 0);
-}
-
-TEST(Tuple, broadenTODO_2) {
-    using Small = Tuple<char, int>;
-    using Large = Tuple<int, float, char, int>;
-
-    auto s = Small{'c', 23};
-    // other order / bigger
-    // TODO CK: Why does this compile when  broaden chack1 does not compile?
-    auto l = Large(s);
-
-    EXPECT_EQ((l.of<char>()), 'c');
-    EXPECT_EQ((l.of<float>()), 0);
-
-    EXPECT_EQ((l.at<0>()), 23);
-    EXPECT_EQ((l.at<1>()), 0);
-    EXPECT_EQ((l.at<2>()), 'c');
-    // TODO CK: Value 23 - what is expected? I think it should prevent the creation as incompatible!
-    // ASSERT_EQ((l.at<3>()), 0);
 }
 
 TEST(Tuple, shrink) {


### PR DESCRIPTION
This patch moves the "from-lesser" and reordering functionality to special static factory functions, as discussed in #17 
This enables more expressive compiler errors when constructing from a complete set.

Note that this constructor requires a workaround for the empty (Tuple<>) case, in which the definition collides with the default constructor. Also, standard-conformant compilers need to be convinced to use SFINAE first by introducing a dependency on another (defaulted) template argument.