### PR TITLE
Implementing deduction guide

### DIFF
--- a/src/tuple17.lib/tuple17/Tuple.h
+++ b/src/tuple17.lib/tuple17/Tuple.h
@@ -319,6 +319,9 @@ auto constexpr get(const tuple17::Tuple<Ts...>& tuple, ::meta17::Type<T> = {}) -
     return tuple.template of<T>();
 }
 
+template<class... Ts>
+Tuple(Ts...)->Tuple<Ts...>;
+
 } // namespace tuple17
 
 /// for c++17 structured bindings support


### PR DESCRIPTION
To prevent this warning in clang:
warning: 'Tuple' may not intend to support class template argument deduction
Tuple.h:79:8: note: add a deduction guide to suppress this warning