### PR TITLE
Bugfix for check that was not working

### DIFF
--- a/src/meta17.lib/meta17/TypePack.indexOf.h
+++ b/src/meta17.lib/meta17/TypePack.indexOf.h
@@ -52,13 +52,14 @@ constexpr auto typePackOverflowIndexOf(TP, Type<T> = {}) {
     return indexed_type_pack_overflow_index_of<T, TP, IndexPackFor<TP>>;
 }
 
-/// statically asserts that the returned index is valid
+// TODO(mstaff): the functions with the prefix indexed should not be used. Can we indicate that or prevent usage?
+
 template<class T, class TP, class IP>
 constexpr auto indexed_type_pack_index_of = same<TP, TP>&& META17_DEFER_STATIC_ERROR("not a type pack");
 
 template<class T, class... Ts, size_t... Is>
-constexpr auto indexed_type_pack_index_of<T, TypePack<Ts...>, IndexPack<Is...>> = //
-    1 == countOf<T, Ts...>() ? (((type<Ts> == type<T>) ? Is : 0) + ...) : META17_DEFER_STATIC_ERROR("type not found");
+constexpr auto indexed_type_pack_index_of<T, TypePack<Ts...>, IndexPack<Is...>> =
+    (((type<Ts> == type<T>) ? Is : 0) + ...);
 
 template<class T, class TP, class IP>
 constexpr auto indexedTypePackIndexOf(TP = {}, IP = {}, Type<T> = {}) -> size_t {
@@ -68,11 +69,11 @@ constexpr auto indexedTypePackIndexOf(TP = {}, IP = {}, Type<T> = {}) -> size_t 
 }
 
 template<class T, class TP>
-constexpr auto type_pack_index_of = indexed_type_pack_index_of<T, TP, IndexPackFor<TP>>;
+constexpr auto type_pack_index_of = indexedTypePackIndexOf<T, TP, IndexPackFor<TP>>();
 
 template<class T, class TP>
 constexpr auto typePackIndexOf(TP = {}, Type<T> = {}) {
-    return indexed_type_pack_index_of<T, TP, IndexPackFor<TP>>;
+    return indexedTypePackIndexOf<T, TP, IndexPackFor<TP>>();
 }
 
 } // namespace meta17


### PR DESCRIPTION
The helper functions type_pack_index_of and typePackIndexOf previously did not check wether the given type was present multiple times in the typepack to be searched. Constructs like `type_pack_index_of<int, TypePack<int, int, int, int>>` were possible. Fixed this by using a different helper function where the check works and removing the check from the previously used helper function as it is not necessary.