### PR TITLE
Fix to make opaque strong usable everywhere

### DIFF
--- a/src/strong17.lib/strong17/Strong.opaque.h
+++ b/src/strong17.lib/strong17/Strong.opaque.h
@@ -13,7 +13,7 @@
         return {};                                                                                                     \
     }                                                                                                                  \
     struct NAME : strong17::Strong<TYPE, ##__VA_ARGS__> {                                                              \
-        using Strong::Strong;                                                                                          \
+        using strong17::Strong<TYPE, ##__VA_ARGS__>::Strong;                                                           \
     }
 
 #define STRONG_OPAQUE_TYPE(NAME, STRONG_TYPE)                                                                          \


### PR DESCRIPTION
Previously it only worked with `using strong17::Strong` or similar.