### PR TITLE
forEachIndex as "constexpr for": Iterate over a sequence with compile-time available indices

### DIFF
--- a/src/meta17.lib/meta17/IndexPack.iterate.h
+++ b/src/meta17.lib/meta17/IndexPack.iterate.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "Index.h"
+#include "IndexPack.h"
+
+namespace meta17 {
+
+/// "constexpr for": Iterate over a sequence with compile-time available indices
+template <class Callable, size_t... Is>
+constexpr auto forEachIndex(IndexPack<Is...>, Callable &&callable) {
+  return (..., callable(Index<Is>{}));
+}
+
+} // namespace meta17

--- a/src/meta17.lib/meta17/meta17.qbs
+++ b/src/meta17.lib/meta17/meta17.qbs
@@ -50,6 +50,7 @@ Product {
             "IndexPack.extract.h",
             "IndexPack.for.h",
             "IndexPack.h",
+            "IndexPack.iterate.h",
             "IndexPack.make.h",
             "IndexPack.ops.h",
             "IndexPack.trait.h",


### PR DESCRIPTION
This is useful in type conversions that deal with both static type lists, and uniform vectors of dynamic storage.