### PR TITLE
Implementing is_variant_which

### DIFF
--- a/src/variant17.lib/variant17/Variant.h
+++ b/src/variant17.lib/variant17/Variant.h
@@ -64,6 +64,9 @@ struct VariantWhich {
     static constexpr auto pack = to_type_pack<Ts...>;
     static constexpr auto indices = indexPackFor(pack);
     using WhichValue = UnwrapType<SelectType<sizeof...(Ts)>>; // enough for npos!
+
+    constexpr VariantWhich()
+        : value(0) {}
     explicit constexpr VariantWhich(WhichValue v)
         : value(v) {}
 

--- a/src/variant17.lib/variant17/Variant.h
+++ b/src/variant17.lib/variant17/Variant.h
@@ -59,6 +59,37 @@ auto selectType() {
 template<size_t N>
 using SelectType = UnwrapType<decltype(selectType<N>())>;
 
+template<class... Ts>
+struct VariantWhich {
+    static constexpr auto pack = to_type_pack<Ts...>;
+    static constexpr auto indices = indexPackFor(pack);
+    using WhichValue = UnwrapType<SelectType<sizeof...(Ts)>>; // enough for npos!
+    explicit constexpr VariantWhich(WhichValue v)
+        : value(v) {}
+
+    constexpr operator WhichValue() const { return value; }
+
+    constexpr bool operator==(VariantWhich w) const { return w.value == value; }
+    constexpr bool operator!=(VariantWhich w) const { return w.value != value; }
+
+    template<class T>
+    constexpr bool operator==(Type<T>) const {
+        return whichOf<T>() == *this;
+    }
+    template<class T>
+    constexpr bool operator!=(Type<T>) const {
+        return whichOf<T>() != *this;
+    }
+
+    template<class T>
+    constexpr static auto whichOf(Type<T> = {}) -> VariantWhich {
+        return VariantWhich{static_cast<WhichValue>(indexedTypePackIndexOf<T>(pack, indices))};
+    }
+
+private:
+    WhichValue value;
+};
+
 /// Variant != std::variant
 /// * unchecked invalid state (only destruction is valid!)
 /// * simple recursive vistor
@@ -66,33 +97,12 @@ using SelectType = UnwrapType<decltype(selectType<N>())>;
 /// * sizeof(index) limits
 template<class... Ts>
 struct Variant {
-    static constexpr auto pack = to_type_pack<Ts...>;
-    static constexpr auto indices = indexPackFor(pack);
+    using Which = VariantWhich<Ts...>;
+    static constexpr auto pack = Which::pack;
+    static constexpr auto indices = Which::indices;
     using First = TypeHead<decltype(pack)>;
-    using WhichValue = UnwrapType<SelectType<sizeof...(Ts)>>; // enough for npos!
+    using WhichValue = typename Which::WhichValue;
     enum { npos = sizeof...(Ts) }; // invalid state after exception - only destruction checks!
-
-    struct Which {
-        explicit constexpr Which(WhichValue v)
-            : value(v) {}
-
-        constexpr operator WhichValue() const { return value; }
-
-        constexpr bool operator==(Which w) const { return w.value == value; }
-        constexpr bool operator!=(Which w) const { return w.value != value; }
-
-        template<class T>
-        constexpr bool operator==(Type<T>) const {
-            return whichOf<T>() == *this;
-        }
-        template<class T>
-        constexpr bool operator!=(Type<T>) const {
-            return whichOf<T>() != *this;
-        }
-
-    private:
-        WhichValue value;
-    };
 
 private:
     std::aligned_union_t<0, Ts...> m{};
@@ -171,7 +181,7 @@ public:
     Variant(T&& t) {
         static_assert(containsOf<BT>(pack), "type not part of variant");
         constructOf(type<BT>, std::forward<T>(t));
-        whichValue = whichOf<BT>();
+        whichValue = Which::whichOf(type<BT>);
     }
 
     /// inplace construct of type
@@ -179,7 +189,7 @@ public:
     Variant(Type<T>, Args&&... args) {
         static_assert(containsOf<T>(pack), "type not part of variant");
         constructOf(type<T>, std::forward<Args>(args)...);
-        whichValue = whichOf<T>();
+        whichValue = Which::whichOf(type<T>);
     }
 
     template<size_t I, class... Args>
@@ -207,12 +217,7 @@ public:
         if (whichValue != npos) destruct();
         whichValue = npos;
         constructOf(type<T>, std::forward<Args>(args)...);
-        whichValue = whichOf<T>();
-    }
-
-    template<class T>
-    constexpr static auto whichOf(Type<T> = {}) -> Which {
-        return Which{static_cast<WhichValue>(indexedTypePackIndexOf<T>(pack, indices))};
+        whichValue = Which::whichOf(type<T>);
     }
 
     template<size_t I>

--- a/src/variant17.lib/variant17/Variant.test.cpp
+++ b/src/variant17.lib/variant17/Variant.test.cpp
@@ -76,7 +76,7 @@ TEST(Variant, which) {
     ASSERT_NE(v.which(), type<int>);
     ASSERT_EQ(v.which(), type<float>);
 
-    static_assert(V::whichOf<char>() == type<char>);
+    static_assert(V::Which::whichOf<char>() == type<char>);
     // Should not compile due to double is not part of V
     // static_assert(V::whichOf<double>() == type<double>);
 }

--- a/src/variant17.lib/variant17/Variant.test.cpp
+++ b/src/variant17.lib/variant17/Variant.test.cpp
@@ -76,7 +76,7 @@ TEST(Variant, which) {
     ASSERT_NE(v.which(), type<int>);
     ASSERT_EQ(v.which(), type<float>);
 
-    static_assert(V::Which::whichOf<char>() == type<char>);
+    static_assert(V::whichOf<char>() == type<char>);
     // Should not compile due to double is not part of V
     // static_assert(V::whichOf<double>() == type<double>);
 }

--- a/src/variant17.lib/variant17/Variant.trait.h
+++ b/src/variant17.lib/variant17/Variant.trait.h
@@ -9,4 +9,10 @@ constexpr auto is_variant = false;
 template<class... Ts>
 constexpr auto is_variant<Variant<Ts...>> = true;
 
+template<class T>
+constexpr auto is_variant_which = false;
+
+template<class... Ts>
+constexpr auto is_variant_which<VariantWhich<Ts...>> = true;
+
 } // namespace variant17

--- a/src/variant17.lib/variant17/Variant.trait.test.cpp
+++ b/src/variant17.lib/variant17/Variant.trait.test.cpp
@@ -8,14 +8,21 @@ using namespace variant17;
 TEST(Variant, trait) {
     using T = Variant<int, double, char, short, bool>;
     static_assert(is_variant<T>);
+    static_assert(!is_variant_which<T>);
+
+    static_assert(!is_variant<T::Which>);
+    static_assert(is_variant_which<T::Which>);
 
     struct S {
         int i;
     };
     static_assert(!is_variant<S>);
+    static_assert(!is_variant_which<S>);
 
     using P = std::pair<int, double>;
     static_assert(!is_variant<P>);
+    static_assert(!is_variant_which<P>);
 
     static_assert(!is_variant<int>);
+    static_assert(!is_variant_which<int>);
 }


### PR DESCRIPTION
Also moving Variant<T>::Which to VariantWhich<T>, which is necessary to create is_variant_which.